### PR TITLE
feat(Library): Use NgZone for Vis-timeline

### DIFF
--- a/components/timeline/vis-timeline.service.spec.ts
+++ b/components/timeline/vis-timeline.service.spec.ts
@@ -3,9 +3,12 @@ import { VisTimelineService } from './vis-timeline.service';
 
 describe('VisTimelineService Tests', () => {
   let visTimelineService: VisTimelineService;
+  const ngZoneMock: any = {
+    runOutsideAngular: (fn: () => void) => fn()
+  };
 
   beforeEach(() => {
-    visTimelineService = new VisTimelineService();
+    visTimelineService = new VisTimelineService(ngZoneMock);
   });
 
   it('throws no error when the network does not exist', () => {

--- a/components/timeline/vis-timeline.service.ts
+++ b/components/timeline/vis-timeline.service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Injectable } from '@angular/core';
+import { EventEmitter, Injectable, NgZone } from '@angular/core';
 import {
   DataGroupCollectionType,
   DataItemCollectionType,
@@ -133,6 +133,10 @@ export class VisTimelineService {
 
   private timelines: { [id: string]: Timeline } = {};
 
+  constructor(
+    private ngZone: NgZone
+  ) { }
+
   /**
    * Creates a new timeline instance.
    *
@@ -150,7 +154,7 @@ export class VisTimelineService {
       throw new Error(this.alreadyExistsError(visTimeline));
     }
 
-    this.timelines[visTimeline] = new Timeline(container, items, options);
+    this.timelines[visTimeline] = this.ngZone.runOutsideAngular(() => new Timeline(container, items, options));
   }
 
   /**
@@ -177,7 +181,7 @@ export class VisTimelineService {
       throw new Error(this.alreadyExistsError(visTimeline));
     }
 
-    this.timelines[visTimeline] = new Timeline(container, items, groups, options);
+    this.timelines[visTimeline] = this.ngZone.runOutsideAngular(() => new Timeline(container, items, groups, options));
   }
 
   /**


### PR DESCRIPTION
## :memo: Description

Because vis-timeline uses `setTimeout` as well as `setInterval` Angular ChangeDetection will be triggered regularly. This causes performance issues as described in #388. Running the timeline outside of the zone will not trigger the ChangeDetection all the time.

### :dart: Relevant issues
#388

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

Might cause some breaking changes so this needs further testing.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
