### PR TITLE
fix(network): Make nodeIds optional on getPositions()

### DIFF
--- a/components/network/vis-network.service.ts
+++ b/components/network/vis-network.service.ts
@@ -1027,7 +1027,7 @@ export class VisNetworkService {
    * @param {Array.<Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
    * @returns {{}}
    */
-  public getPositions(visNetwork: string, nodeIds: IdType[]) {
+  public getPositions(visNetwork: string, nodeIds?: IdType[]) {
     return this.networks[visNetwork].getPositions(nodeIds);
   }
 


### PR DESCRIPTION
Created issue 404 for problem, change is trivial

## :memo: Description

Made argument nodeIds optional as the comments on method specify, and the js library supports it, verified on the code

### :dart: Relevant issues
Issue 404 was created with a longer description

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

  /**
   * Returns the positions of the nodes.
   * @param {string} visNetwork The network name/identifier.
   * @param {Array.<Node.id>|String} [ids]  --> optional, can be array of nodeIds, can be string
   * @returns {{}}
   */
  public getPositions(visNetwork: string, nodeIds?: IdType[]) {
    return this.networks[visNetwork].getPositions(nodeIds);
  }
``` 

## :vertical_traffic_light: How Has This Been Tested?
No new tests was added, could do, but might need instructions, again change is trivial. Ran npm test with no errors

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [x] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
